### PR TITLE
Fix overflow of 2 sides in emulator mode

### DIFF
--- a/emulator.glsl
+++ b/emulator.glsl
@@ -119,7 +119,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 	float pixSize = .35;
 	vec4 sideCoord = cube_map_to_side(p);
 	if (length(mod(sideCoord.xy * grid, 1) - .5) < pixSize) {
-		mainCube(fragColor, round(p * grid - .5) / grid);
+		mainCube(fragColor, p);
 	} else {
 		fragColor = vec4(0);
 	}


### PR DESCRIPTION
I started experimenting with your shaders some hours ago. The approach looks pretty interesting. The whole shader thing is new for me, but it looks pretty exciting.

During my first steps I tried to fill all sides of the cube with different colors in emulator mode. I noticed that the colors of two sides of the cube were visible at the edge of the adjacent sides.

After some tests I found out that the problem occurs only with active "EMU_GRID" and built the attached fix.

 Enclosed is a picture showing the problem. And then another one I made after my change.

![bug](https://user-images.githubusercontent.com/2719629/54466732-7a511c00-4781-11e9-88ad-c86f4c5844d1.png)
![fixed](https://user-images.githubusercontent.com/2719629/54466733-7a511c00-4781-11e9-88f1-5a5376db69a4.png)

Thanks for your work! :-)